### PR TITLE
Install gscloud and gsutil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -73,3 +73,23 @@ ones you probably want to set:
      }
    ]
    ```
+
+* `GS_SERVICE_ACCOUNT_KEY`: if you use Google Storage to write history, set this to your service account key:
+  ```json
+  {
+    "type": "service_account",
+    "project_id": "project-name",
+    "private_key_id": "0n7n7cnqp84489",
+    "private_key": "-----BEGIN PRIVATE KEY-----..."
+  }
+  ```
+
+  Your history can then have something like this for read/write:
+
+  ```json
+  {
+    "local": {
+      "get": "/gsutil cp gs://bucket-name/prod/01/{0} {1}",
+      "put": "/gsutil cp {0} gs://bucket-name/prod/01/{1}"
+  }
+  ```

--- a/entry.sh
+++ b/entry.sh
@@ -19,8 +19,18 @@ function stellar_core_init_db() {
   touch $DB_INITIALIZED
 }
 
+function setup_gsutil() {
+  if [ -n "$GS_SERVICE_ACCOUNT_KEY" ]; then
+    echo "Setting up gsutil: writing contents of GS_SERVICE_ACCOUNT_KEY into /tmp/gcloud-key.json..."
+    echo $GS_SERVICE_ACCOUNT_KEY > /tmp/gcloud-key.json
+    gcloud auth activate-service-account --key-file /tmp/gcloud-key.json
+    echo "gsutil configured"
+  fi
+}
+
 confd -onetime -backend env -log-level error
 
 stellar_core_init_db
+setup_gsutil
 
 exec "$@"

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,16 @@ rm -rf stellar-core
 apt-get remove -y $STELLAR_CORE_BUILD_DEPS
 apt-get autoremove -y
 
+# install gcloud and gsutil
+apt-get update -qq
+apt-get install lsb-release curl -y
+export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+echo "CLOUD_SDK_REPO: $CLOUD_SDK_REPO"
+echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+apt-get update -qq
+apt-get install google-cloud-sdk -qqy
+
 # install deps
 apt-get install -y $STELLAR_CORE_DEPS
 


### PR DESCRIPTION
This installs gscloud and gsutil so that core can fetch and get data from Google Storage buckets. If writing into a GS bucket is not needed, this can remain empty.