### PR TITLE
introduce DATABASE_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Docker images are automatically built and published at [satoshipay/stellar-c
 The container can be fully configured via environment variables, see below.
 
 There is also an [example Docker Compose config](docker-compose.example.yml) – just run
-`docker-compose -f docker-compose.example.yml` to get a functional node.
+`docker-compose -f docker-compose.example.yml up` to get a functional node.
 **Make sure to use a new `NODE_SEED` if you intend to run this in production!**
 
 ### Create node seed
@@ -34,7 +34,13 @@ ones you probably want to set:
   is the public production network; use `Test SDF Network ; September 2015` for the testnet.
 
 * `DATABASE`: default is `sqlite3://stellar.db` which you should definitely change for production,
-   e.g., `postgresql://dbname=stellar user=postgres host=postgres`.
+   e.g., `postgresql://dbname=stellar user=postgres host=postgres` or
+   `postgresql://dbname=stellar user=postgres password=DATABASE_PASSWORD host=postgres`
+   (see `DATABASE_PASSWORD`).
+
+* `DATABASE_PASSWORD`: if provided, the string `DATABASE_PASSWORD` in the `DATABASE`
+   variable is replace with its value. This is useful for providing passwords separately,
+   e.g., via secrets in Kubernetes.
 
 * `KNOWN_PEERS`: comma-separated list of peers (`ip:port`) to connect to when
    below *TARGET_PEER_CONNECTIONS*, e.g.,

--- a/confd/templates/stellar-core.cfg.tmpl
+++ b/confd/templates/stellar-core.cfg.tmpl
@@ -2,7 +2,11 @@ LOG_FILE_PATH="{{getenv "LOG_FILE_PATH"}}"
 
 BUCKET_DIR_PATH="/data/buckets"
 
+{{if (getenv "DATABASE_PASSWORD")}}
+DATABASE="{{replace (getenv "DATABASE") "DATABASE_PASSWORD" (getenv "DATABASE_PASSWORD") -1}}"
+{{else}}
 DATABASE="{{getenv "DATABASE"}}"
+{{end}}
 
 HTTP_PORT=11626
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -8,13 +8,14 @@ services:
       - POSTGRES_DB=stellar-core
 
   stellar-core:
-    image: satoshipay/stellar-core:9.2.0
+    image: satoshipay/stellar-core:9.2.0-1
     restart: always
     ports:
     - 11625:11625
     - 11626:11626
     environment:
-      - DATABASE=postgresql://dbname=stellar-core user=postgres host=stellar-core-postgres
+      - DATABASE=postgresql://dbname=stellar-core user=postgres password=DATABASE_PASSWORD host=stellar-core-postgres
+      - DATABASE_PASSWORD=2aq853RGDqdHAWFwGDSGGRIUP9VzJJsh
       # WARNING: make sure to use a new NODE_SEED!
       # public key GD4E3XVLEBB4JMR7KNNMTSGXIKOK56ZZXX764KEPKE4IR73DEG6O22SI
       - NODE_SEED=SCBQ3PUIFODWT3IH2H36IB7ZWT2FKNZQTS6ZZ3QIXS63IFIXZEGRTBUM my_stellar_node


### PR DESCRIPTION
Relevant if you want to provide a password separately, e.g., via Kubernetes' secrets.