### PR TITLE
add readiness (synced) check script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch
 # git tag from https://github.com/stellar/stellar-core
 ARG STELLAR_CORE_VERSION="v9.2.0"
 ARG STELLAR_CORE_BUILD_DEPS="git build-essential pkg-config autoconf automake libtool bison flex libpq-dev wget pandoc"
-ARG STELLAR_CORE_DEPS="curl libpq5"
+ARG STELLAR_CORE_DEPS="curl jq libpq5"
 ARG CONFD_VERSION="0.12.0"
 
 LABEL maintainer="hello@satoshipay.io"
@@ -27,6 +27,7 @@ ENV \
   HTTP_MAX_CLIENT="128" \
   NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 
+ADD ready.sh /
 ADD confd /etc/confd
 
 ADD entry.sh /

--- a/ready.sh
+++ b/ready.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu pipefail
+
+STATE=`curl --silent http://localhost:11626/info | jq -r .info.state`
+
+if [ "${STATE}" == "Synced!" ]; then
+  exit 0
+else
+  >&2 echo "Expected state \"Synced!\" but got \"${STATE}\""
+  exit 1
+fi


### PR DESCRIPTION
The new script `ready.sh` exits with zero exit code if the state is `Synced!` and with `1` otherwise. Useful as a `readinessProbe` in Kubernetes.